### PR TITLE
fix broken link

### DIFF
--- a/_papers/j001-graded.md
+++ b/_papers/j001-graded.md
@@ -1,7 +1,7 @@
 ---
 layout: paper
 type: journal
-arxiv: 0711.2838
+arxiv: "0711.2838"
 doi: 10.3217/jucs-013-11
 journal: jucs
 authors:


### PR DESCRIPTION
So the probem is: 0711.2838 is treated as a number and the leading zero is removed. When forming the link later here:
https://github.com/theran/theran.github.io/blob/e9ca1ae0a3ce3f1c40f448956eacea9e62ae6c21/_layouts/paper.html#L69
it becomes a dead link. An other method to fix that would be to check the length somewhere and put back the zeros..
